### PR TITLE
Fix i586

### DIFF
--- a/modelmachine/tests/test_cu_abstract.py
+++ b/modelmachine/tests/test_cu_abstract.py
@@ -12,6 +12,7 @@ from modelmachine.memory import RegisterMemory, RandomAccessMemory
 from modelmachine.alu import ArithmeticLogicUnit, HALT
 
 BYTE_SIZE = 8
+HALF_SIZE = 16
 WORD_SIZE = 32
 
 OP_MOVE = 0x00

--- a/modelmachine/tests/test_cu_variable.py
+++ b/modelmachine/tests/test_cu_variable.py
@@ -12,7 +12,8 @@ from modelmachine.cu import ControlUnitM
 from modelmachine.memory import RegisterMemory, RandomAccessMemory
 from modelmachine.alu import ArithmeticLogicUnit
 
-from .test_cu_abstract import (BYTE_SIZE, WORD_SIZE, OP_MOVE, OP_COMP,
+from .test_cu_abstract import (BYTE_SIZE, HALF_SIZE, WORD_SIZE,
+                               OP_MOVE, OP_COMP,
                                OP_SDIVMOD, OP_UDIVMOD,
                                OP_LOAD, OP_STORE, OP_RMOVE,
                                OP_RADD, OP_RSUB, OP_RSMUL, OP_RSDIVMOD,
@@ -185,9 +186,9 @@ class TestControlUnitM(TBCU2):
     def setup(self):
         """Init state."""
         super().setup()
-        self.ram = RandomAccessMemory(2 * BYTE_SIZE, 2 ** WORD_SIZE, 'big', is_protected=True)
+        self.ram = RandomAccessMemory(HALF_SIZE, 2 ** HALF_SIZE, 'big', is_protected=True)
         self.control_unit = ControlUnitM(WORD_SIZE,
-                                         2 * BYTE_SIZE,
+                                         HALF_SIZE,
                                          self.registers,
                                          self.ram,
                                          self.alu,


### PR DESCRIPTION
Fix #9 
Ранее был неправильный размер виртуальной памяти (но только в тестах, в рабочей версии все как было нормально, так и осталось).
